### PR TITLE
refactor(api)!: use session cookie auth

### DIFF
--- a/include/mix.h
+++ b/include/mix.h
@@ -85,6 +85,7 @@ struct source_pc {
 
 struct session {
 	struct le le;
+	bool auth;
 	struct peer_connection *pc;
 	struct list source_pcl;
 	struct http_conn *conn_pending;

--- a/include/mix.h
+++ b/include/mix.h
@@ -198,8 +198,8 @@ int user_event_json(char **json, enum user_event event, struct session *sess);
  */
 int sl_ws_init(void);
 int sl_ws_close(void);
-int sl_ws_open(struct http_conn *conn, const struct http_msg *msg,
-	       websock_recv_h *recvh, struct mix *mix);
+int sl_ws_open(struct http_conn *httpc, const struct http_msg *msg,
+	       struct mix *mix, struct session *sess);
 void sl_ws_send_event(struct session *sess, char *str);
 void sl_ws_send_event_self(struct session *sess, char *str);
 void sl_ws_send_event_all(char *json);

--- a/src/sess.c
+++ b/src/sess.c
@@ -325,13 +325,18 @@ struct session *slmix_session_lookup_hdr(const struct list *sessl,
 {
 	const struct http_hdr *hdr;
 
-	hdr = http_msg_xhdr(msg, "Session-ID");
+	hdr = http_msg_xhdr(msg, "Cookie");
 	if (!hdr) {
-		warning("mix: no Session-ID header\n");
+		warning("mix: no Session Cookie header\n");
 		return NULL;
 	}
 
-	return slmix_session_lookup(sessl, &hdr->val);
+	struct pl token;
+	if (re_regex(hdr->val.p, hdr->val.l, "mix_session=[a-z0-9A-Z]+",
+		     &token))
+		return NULL;
+
+	return slmix_session_lookup(sessl, &token);
 }
 
 

--- a/webui/src/avdummy.ts
+++ b/webui/src/avdummy.ts
@@ -21,7 +21,7 @@ function draw() {
     ctx.font = "48px serif";
     ctx.textAlign = "center"
     ctx.fillStyle = "gray";
-    ctx.fillText(api.session().user_name, width / 2, height / 2 + image.height / 2);
+    ctx.fillText(api.user_id()!, width / 2, height / 2 + image.height / 2);
     ctx.drawImage(image, width / 2 - (image.width / 2), (height / 2 - image.height / 2) - 48)
 }
 
@@ -48,7 +48,7 @@ const black = () => {
 
     ctx.fillRect(0, 0, width, height)
 
-    image.src = '/avatars/' + api.session().user_id + '.png'
+    image.src = '/avatars/' + api.user_id() + '.png'
     image.onload = () => {
         drawCount = 0
         //Chrome workaround: needs canvas frame change to start webrtc rtp

--- a/webui/src/avdummy.ts
+++ b/webui/src/avdummy.ts
@@ -1,4 +1,5 @@
 import api from './api'
+import { Users } from './ws/users'
 
 const width = 1280
 const height = 720
@@ -14,14 +15,12 @@ function draw() {
     if (!ctx)
         return
 
-    console.log("draw", drawCount)
-
     ctx.fillStyle = "black";
     ctx.fillRect(0, 0, width, height)
     ctx.font = "48px serif";
     ctx.textAlign = "center"
     ctx.fillStyle = "gray";
-    ctx.fillText(api.user_id()!, width / 2, height / 2 + image.height / 2);
+    ctx.fillText(Users.user_name.value, width / 2, height / 2 + image.height / 2);
     ctx.drawImage(image, width / 2 - (image.width / 2), (height / 2 - image.height / 2) - 48)
 }
 

--- a/webui/src/components/BottomActions.vue
+++ b/webui/src/components/BottomActions.vue
@@ -199,7 +199,7 @@ import { PlayCircleIcon } from '@heroicons/vue/24/solid'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import ReactionEmoji from '../components/ReactionEmoji.vue'
 
-const user_id = api.session()?.user_id
+const user_id = api.user_id()
 const hand_status = Users.hand_status
 const version = ref(APP_VERSION)
 
@@ -220,7 +220,7 @@ function hand_clicked() {
 function mic_clicked(mute: boolean) {
   if (Webrtc.state.value < WebrtcState.ReadySpeaking) {
     Users.settings_active.value = true
-    if (!Users.room.value?.show) api.speaker(api.session().user_id)
+    if (!Users.room.value?.show) api.speaker(api.user_id())
   } else Webrtc.audio_mute(mute)
 }
 
@@ -240,7 +240,7 @@ async function settings_clicked() {
 }
 
 function logout_clicked() {
-  api.logout(true)
+  api.logout()
 }
 
 function hangup_clicked() {

--- a/webui/src/components/Chat.vue
+++ b/webui/src/components/Chat.vue
@@ -137,7 +137,7 @@ const msg = ref('')
 const scroll_stop = ref(false)
 const chat = ref<HTMLElement | null>(null)
 
-const user_id = api.session().user_id
+const user_id = api.user_id()
 const md = markdownit({
   html: false,
   linkify: true,

--- a/webui/src/components/SettingsModal.vue
+++ b/webui/src/components/SettingsModal.vue
@@ -257,6 +257,6 @@ function join() {
 function join_listen() {
   open.value = false
   Webrtc.state.value = WebrtcState.Listening
-  api.listener(api.session().user_id)
+  api.listener(api.user_id())
 }
 </script>

--- a/webui/src/components/Speakers.vue
+++ b/webui/src/components/Speakers.vue
@@ -113,7 +113,7 @@
                   To Audience
                 </button>
                 <button
-                  v-if="!Users.host_status.value && item.id === api.session().user_id && room?.show"
+                  v-if="!Users.host_status.value && item.id === api.user_id() && room?.show"
                   @click="api.listener(item.id)"
                   type="button"
                   class="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-2.5 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"

--- a/webui/src/components/WebrtcVideo.vue
+++ b/webui/src/components/WebrtcVideo.vue
@@ -56,7 +56,7 @@
         :style="{ width: calc_width(), height: calc_height(), left: calc_left(index), top: calc_top(index) }"
       >
         <video
-          v-if="item.id == api.session().user_id"
+          v-if="item.id == api.user_id()"
           :class="{'scale-x-[-1]': Webrtc.video_select.value !== 'Screen'}"
           class="object-cover h-full w-full"
           id="selfview"
@@ -147,7 +147,7 @@ Audio RTT: {{ item.stats.artt }} ms
             To Audience
           </button>
           <button
-            v-if="!Users.host_status.value && item.id === api.session().user_id && room?.show"
+            v-if="!Users.host_status.value && item.id === api.user_id() && room?.show"
             @click="api.listener(item.id)"
             type="button"
             class="hidden group-hover:inline-flex ml-2 items-center rounded-md border border-transparent bg-indigo-600 px-2.5 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
@@ -220,7 +220,7 @@ Audio RTT: {{ item.stats.artt }} ms
             Disable Audio
           </button>
           <button
-            v-if="item.video && selfview && item.id === api.session().user_id"
+            v-if="item.video && selfview && item.id === api.user_id()"
             @click="selfview = false"
             type="button"
             class="hidden group-hover:inline-flex ml-2 items-center rounded-md border border-transparent bg-indigo-600 px-2.5 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
@@ -229,7 +229,7 @@ Audio RTT: {{ item.stats.artt }} ms
             Disable Selfview
           </button>
           <button
-            v-if="item.video && !selfview && item.id === api.session().user_id"
+            v-if="item.video && !selfview && item.id === api.user_id()"
             @click="selfview = true"
             type="button"
             class="hidden group-hover:inline-flex ml-2 items-center rounded-md border border-transparent bg-indigo-600 px-2.5 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"

--- a/webui/src/config.ts
+++ b/webui/src/config.ts
@@ -8,20 +8,12 @@ export default {
         return '/'
     },
     host(): string {
-        if (process.env.NODE_ENV == 'production') {
-            return location.origin
-        }
-        /* Development */
-        return 'http://' + location.hostname + ':9999'
+        return location.origin
     },
     ws_host(): string {
-        if (process.env.NODE_ENV == 'production') {
-            if (location.protocol == 'https:')
-                return 'wss://' + location.host
-            else
-                return 'ws://' + location.host
-        }
-        /* Development */
-        return 'ws://' + location.hostname + ':9999'
+        if (location.protocol == 'https:')
+            return 'wss://' + location.host
+        else
+            return 'ws://' + location.host
     },
 }

--- a/webui/src/router/index.ts
+++ b/webui/src/router/index.ts
@@ -25,13 +25,12 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to) => {
+  await api.connect(to.params.token)
   const auth = await api.isAuthenticated()
   if (!auth && to.name !== 'Login') {
     return { name: 'Login' }
   }
   if (auth && to.name === 'Login') {
-    if (to.params.token)
-        await api.reauth(to.params.token) 
     return { name: 'Home' }
   }
 })

--- a/webui/src/views/FatalErrorView.vue
+++ b/webui/src/views/FatalErrorView.vue
@@ -31,6 +31,6 @@
 <script setup lang="ts">
 import api from '../api'
 function logout_clicked() {
-  api.logout(false)
+  api.logout()
 }
 </script>

--- a/webui/src/views/LoginView.vue
+++ b/webui/src/views/LoginView.vue
@@ -76,8 +76,10 @@ import FooterLinks from '../components/FooterLinks.vue'
 import webcam from '../webcam'
 import api from '../api'
 
+/*
 const vprops = defineProps({ token: String })
 api.connect(vprops?.token)
+*/
 
 const error = ref(false)
 const name = ref('')

--- a/webui/src/ws/users.ts
+++ b/webui/src/ws/users.ts
@@ -138,7 +138,7 @@ export const Users: Users = {
                         this.hand_status.value = data.users[key].hand
                         this.speaker_status.value = data.users[key].speaker
                         this.host_status.value = data.users[key].host
-                        this.user_name = data.users[key].name
+                        this.user_name.value = data.users[key].name
                     }
 
                     if (data.users[key].name.startsWith('sip:'))

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -11,4 +11,10 @@ export default defineConfig({
     define: {
         APP_VERSION: JSON.stringify("v1.0.0-beta-" + commitHash)
     },
+    server: {
+        proxy: {
+            '/api': { target: 'http://127.0.0.1:9999' },
+            '/ws': { target: 'ws://127.0.0.1:9999' },
+        }
+    }
 })


### PR DESCRIPTION
- **Session Management**  
  - The `"Session-ID"` header is replaced with a `"Set-Cookie"` header.  
  - A new cookie named `mix_session` is introduced.  

- **WebSocket Handling**  
  - `sl_ws_open` function now accepts an additional `struct session *sess` parameter.  
  - WebSocket authentication is now based on session cookies.  

- **Session Lookup**  
  - `slmix_session_lookup_hdr` now retrieves session IDs from the `Cookie` header instead of `"Session-ID"`.  
  - Parses the `mix_session` cookie to establish user sessions.  

This change improves security and aligns the authentication mechanism with best practices for session management.
